### PR TITLE
Removed the setting of the layer when it is disconnected

### DIFF
--- a/DarkKnight/Network/Client.cs
+++ b/DarkKnight/Network/Client.cs
@@ -229,7 +229,10 @@ namespace DarkKnight.Network
                 {
                     // if the socket have a type and defined, notification the application is desconnected
                     if (socketLayer != SocketLayer.undefined)
+                    {
                         Application.send(ApplicationSend.connectionClosed, new object[] { this });
+                        socketLayer = SocketLayer.undefined;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Improves performance when a client disconnects, because now we set during the disconnection that it is an undefined layer, it does not force the server to listen until the time is over.
